### PR TITLE
Supply full URL to extract_links() and fix handling of relative URLs

### DIFF
--- a/courlan/core.py
+++ b/courlan/core.py
@@ -25,7 +25,13 @@ from .filters import (
 )
 from .network import redirection_test
 from .settings import BLACKLIST
-from .urlutils import extract_domain, get_base_url, fix_relative_urls, is_external, is_known_link
+from .urlutils import (
+    extract_domain,
+    get_base_url,
+    fix_relative_urls,
+    is_external,
+    is_known_link,
+)
 
 
 LOGGER = logging.getLogger(__name__)

--- a/courlan/urlstore.py
+++ b/courlan/urlstore.py
@@ -30,7 +30,7 @@ from urllib.robotparser import RobotFileParser
 from .core import filter_links
 from .filters import lang_filter, validate_url
 from .meta import clear_caches
-from .urlutils import get_host_and_path, is_known_link
+from .urlutils import get_base_url, get_host_and_path, is_known_link
 
 
 LOGGER = logging.getLogger(__name__)
@@ -235,17 +235,18 @@ class UrlStore:
     def add_from_html(
         self,
         htmlstring: str,
-        base_url: str,
+        full_url: str,
         external: bool = False,
         lang: Optional[str] = None,
         with_nav: bool = True,
     ) -> None:
         "Find links in a HTML document, filter them and add them to the data store."
         # lang = lang or self.language
+        base_url = get_base_url(full_url)
         rules = self.get_rules(base_url)
         links, links_priority = filter_links(
             htmlstring=htmlstring,
-            base_url=base_url,
+            full_url=full_url,
             external=external,
             lang=lang or self.language,
             rules=rules,

--- a/courlan/urlutils.py
+++ b/courlan/urlutils.py
@@ -6,7 +6,7 @@ import re
 
 from functools import lru_cache
 from typing import Any, List, Optional, Set, Tuple, Union
-from urllib.parse import urljoin, urlparse, urlunparse, urlunsplit, ParseResult
+from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit, ParseResult
 
 from tld import get_tld
 
@@ -116,12 +116,12 @@ def fix_relative_urls(baseurl: str, url: str) -> str:
     "Prepend protocol and host information to relative links."
     if url.startswith("{"):
         return url
-    base_p = urlparse(baseurl)
-    url_p = urlparse(url)
-    if url_p.netloc not in [base_p.netloc, ""]:
-        if url_p.scheme:
+    base_netloc = urlsplit(baseurl).netloc
+    split_url = urlsplit(url)
+    if split_url.netloc not in (base_netloc, ""):
+        if split_url.scheme:
             return url
-        return urlunparse(url_p._replace(scheme="http"))
+        return urlunsplit(split_url._replace(scheme="http"))
     return urljoin(baseurl, url)
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -99,6 +99,37 @@ def test_fix_relative():
         fix_relative_urls("https://example.org", "../../test.html")
         == "https://example.org/test.html"
     )
+    # sub-directories
+    assert (
+        fix_relative_urls("https://www.example.org/dir/subdir/file.html", "/absolute")
+        == "https://www.example.org/absolute"
+    )
+    assert (
+        fix_relative_urls("https://www.example.org/dir/subdir/file.html", "relative")
+        == "https://www.example.org/dir/subdir/relative"
+    )
+    assert (
+        fix_relative_urls("https://www.example.org/dir/subdir/", "relative")
+        == "https://www.example.org/dir/subdir/relative"
+    )
+    assert (
+        fix_relative_urls("https://www.example.org/dir/subdir", "relative")
+        == "https://www.example.org/dir/relative"
+    )
+    # non-relative URLs
+    assert (
+        fix_relative_urls("https://example.org", "https://www.eff.org")
+        == "https://www.eff.org"
+    )
+    assert (
+        fix_relative_urls("https://example.org", "//www.eff.org")
+        == "http://www.eff.org"
+    )
+    # looks like an absolute URL but is actually a valid relative URL
+    assert (
+        fix_relative_urls("https://example.org", "www.eff.org")
+        == "https://example.org/www.eff.org"
+    )
 
 
 def test_scrub():

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -130,6 +130,19 @@ def test_fix_relative():
         fix_relative_urls("https://example.org", "www.eff.org")
         == "https://example.org/www.eff.org"
     )
+    # misc
+    assert (
+        fix_relative_urls("https://www.example.org/dir/subdir/file.html", "./this:that")
+        == "https://www.example.org/dir/subdir/this:that"
+    )
+    assert (
+        fix_relative_urls("https://www.example.org/test.html?q=test#frag", "foo.html?q=bar#baz")
+        == "https://www.example.org/foo.html?q=bar#baz"
+    )
+    assert (
+        fix_relative_urls("https://www.example.org", "{privacy}")
+        == "{privacy}"
+    )
 
 
 def test_scrub():


### PR DESCRIPTION
Relating to #45

- Rewrite `fix_relative_urls` to allow passing a full URL as the base to compare against
- Adjust all functions that call `fix_relative_urls` to accept full URLs as well

This should fix things on the courlan side. There will still need to be changes to trafilatura to pass full URLs to the courlan functions in order to fix trafilatura's issues with relative URLs, but this change to courlan should still work independently of that.