### PR TITLE
Fix FIND_LINKS_REGEX to match any whitespace after <a

### DIFF
--- a/courlan/core.py
+++ b/courlan/core.py
@@ -34,7 +34,7 @@ from .urlutils import (
 
 LOGGER = logging.getLogger(__name__)
 
-FIND_LINKS_REGEX = re.compile(r"<a [^<>]+?>", re.I)
+FIND_LINKS_REGEX = re.compile(r"<a\s+[^<>]+?>", re.I)
 HREFLANG_REGEX = re.compile(r'hreflang=["\']?([a-z-]+)', re.I)
 LINK_REGEX = re.compile(r'href=["\']?([^ ]+?)(["\' >])', re.I)
 


### PR DESCRIPTION
The regex `<a [^<>]+?>` uses a literal space which misses valid anchor tags that use tabs or multiple spaces between `<a` and the first attribute.

Changing to `<a\s+[^<>]+?>` covers any whitespace character, which is more robust and consistent with how HTML is written in the wild.

Quick check:
```python
import re
old = re.compile(r"<a [^<>]+?>", re.I)
new = re.compile(r"<a\s+[^<>]+?>", re.I)
print(bool(old.search('<a\thref="http://example.com">')))  # False
print(bool(new.search('<a\thref="http://example.com">')))  # True
```
