### PR TITLE
Degrade gracefully on malformed URLs in _parse

### DIFF
--- a/courlan/urlutils.py
+++ b/courlan/urlutils.py
@@ -61,7 +61,11 @@ def extract_domain(
 def _parse(url: str | SplitResult) -> SplitResult:
     "Parse a string or use urllib.parse object directly."
     if isinstance(url, str):
-        parsed_url = urlsplit(unescape(url))
+        try:
+            parsed_url = urlsplit(unescape(url))
+        except ValueError:
+            # malformed URL (e.g. bad IPv6 literal): degrade to empty parts like a hostless URL.
+            parsed_url = SplitResult("", "", "", "", "")
     elif isinstance(url, SplitResult):
         parsed_url = url
     else:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -59,6 +59,22 @@ def test_baseurls():
     assert get_base_url("example.org") == ""
 
 
+def test_malformed_url_degrades():
+    # A malformed URL (bad IPv6 literal) made urlsplit raise a raw ValueError that
+    # leaked out of get_base_url/get_hostinfo; it now degrades like a hostless URL.
+    assert get_base_url("HTTP://[::1]&") == ""
+    assert get_hostinfo("HTTP://[::1]&") == (None, "")
+    # get_host_and_path still raises its own documented incomplete-URL error.
+    with pytest.raises(ValueError, match="incomplete URL"):
+        get_host_and_path("HTTP://[::1]&")
+    # valid and hostless URLs are unaffected.
+    assert get_base_url("https://example.org/") == "https://example.org"
+    assert get_hostinfo("https://example.org/path") == (
+        "example.org",
+        "https://example.org",
+    )
+
+
 def test_fix_relative():
     assert (
         fix_relative_urls("https://example.org", "page.html")


### PR DESCRIPTION
get_base_url()/get_hostinfo() and other helpers that route through the shared _parse() choke point leak a raw ValueError on malformed URLs like `HTTP://[::1]&` ("Invalid IPv6 URL" from urlsplit). These helpers already degrade to empty output for hostless input, so a caller iterating over a list of scraped URLs hits an uncaught crash on one bad entry instead of the same graceful skip.

Wrap the urlsplit call in _parse in a try/except ValueError that returns an empty SplitResult, so malformed URLs degrade like hostless ones. Added a regression test asserting the specific malformed inputs return empty host info rather than raising.

Repro:
```python
from courlan import get_base_url
get_base_url('HTTP://[::1]&')   # ValueError: Invalid IPv6 URL
```