### PR TITLE
fix: skip malformed IPv6 hrefs in fix_relative_urls

### DIFF
--- a/courlan/urlutils.py
+++ b/courlan/urlutils.py
@@ -61,7 +61,10 @@ def extract_domain(
 def _parse(url: str | SplitResult) -> SplitResult:
     "Parse a string or use urllib.parse object directly."
     if isinstance(url, str):
-        parsed_url = urlsplit(unescape(url))
+        try:
+            parsed_url = urlsplit(unescape(url))
+        except ValueError as err:
+            raise ValueError(f"invalid URL: {url}") from err
     elif isinstance(url, SplitResult):
         parsed_url = url
     else:
@@ -72,7 +75,10 @@ def _parse(url: str | SplitResult) -> SplitResult:
 def get_base_url(url: str | SplitResult) -> str:
     """Strip URL of some of its parts to get base URL.
     Accepts strings and urllib.parse ParseResult objects."""
-    parsed_url = _parse(url)
+    try:
+        parsed_url = _parse(url)
+    except ValueError:
+        return ""
     if parsed_url.scheme:
         scheme = parsed_url.scheme + "://"
     else:
@@ -108,9 +114,13 @@ def fix_relative_urls(baseurl: str, url: str) -> str:
     if url.startswith("{"):
         return url
 
-    parsed_base = urlsplit(baseurl)
+    try:
+        parsed_base = urlsplit(baseurl)
+        split_url = urlsplit(url)
+    except ValueError:
+        return url
+
     base_netloc = parsed_base.netloc
-    split_url = urlsplit(url)
 
     if split_url.netloc not in (base_netloc, ""):
         if split_url.scheme:

--- a/courlan/urlutils.py
+++ b/courlan/urlutils.py
@@ -61,10 +61,7 @@ def extract_domain(
 def _parse(url: str | SplitResult) -> SplitResult:
     "Parse a string or use urllib.parse object directly."
     if isinstance(url, str):
-        try:
-            parsed_url = urlsplit(unescape(url))
-        except ValueError as err:
-            raise ValueError(f"invalid URL: {url}") from err
+        parsed_url = urlsplit(unescape(url))
     elif isinstance(url, SplitResult):
         parsed_url = url
     else:
@@ -75,10 +72,7 @@ def _parse(url: str | SplitResult) -> SplitResult:
 def get_base_url(url: str | SplitResult) -> str:
     """Strip URL of some of its parts to get base URL.
     Accepts strings and urllib.parse ParseResult objects."""
-    try:
-        parsed_url = _parse(url)
-    except ValueError:
-        return ""
+    parsed_url = _parse(url)
     if parsed_url.scheme:
         scheme = parsed_url.scheme + "://"
     else:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -151,6 +151,9 @@ def test_fix_relative():
         == "https://www.example.org/foo.html?q=bar#baz"
     )
     assert fix_relative_urls("https://www.example.org", "{privacy}") == "{privacy}"
+    # malformed IPv6 in protocol-relative or base URL must not raise
+    assert fix_relative_urls("https://example.org", "//[::1/path") == "//[::1/path"
+    assert get_base_url("https://[::1") == ""
 
 
 def test_scrub():
@@ -984,6 +987,12 @@ def test_extraction():
         extract_links(None, base_url="https://test.com/", external_bool=False)
     assert not extract_links(None, url="https://test.com/", external_bool=False)
     assert not extract_links("", "https://test.com/", False)
+    # malformed IPv6 protocol-relative href / page URL must not raise
+    pagecontent = '<html><a href="//[::1/path">x</a><a href="/ok">y</a></html>'
+    assert extract_links(pagecontent, "https://example.com/", False) == {
+        "https://example.com/ok"
+    }
+    assert extract_links('<a href="/ok">y</a>', "https://[::1", False) == set()
     # anchor tags matched by the regex but without an href yield no candidate
     pagecontent = '<html><a class="logo">home</a><a name="x">y</a></html>'
     assert not extract_links(pagecontent, "https://test.com/", False)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -151,9 +151,8 @@ def test_fix_relative():
         == "https://www.example.org/foo.html?q=bar#baz"
     )
     assert fix_relative_urls("https://www.example.org", "{privacy}") == "{privacy}"
-    # malformed IPv6 in protocol-relative or base URL must not raise
+    # malformed IPv6 in protocol-relative href must not raise (urlsplit, not _parse)
     assert fix_relative_urls("https://example.org", "//[::1/path") == "//[::1/path"
-    assert get_base_url("https://[::1") == ""
 
 
 def test_scrub():
@@ -987,12 +986,11 @@ def test_extraction():
         extract_links(None, base_url="https://test.com/", external_bool=False)
     assert not extract_links(None, url="https://test.com/", external_bool=False)
     assert not extract_links("", "https://test.com/", False)
-    # malformed IPv6 protocol-relative href / page URL must not raise
+    # malformed IPv6 protocol-relative href must not raise (fix_relative_urls path)
     pagecontent = '<html><a href="//[::1/path">x</a><a href="/ok">y</a></html>'
     assert extract_links(pagecontent, "https://example.com/", False) == {
         "https://example.com/ok"
     }
-    assert extract_links('<a href="/ok">y</a>', "https://[::1", False) == set()
     # anchor tags matched by the regex but without an href yield no candidate
     pagecontent = '<html><a class="logo">home</a><a name="x">y</a></html>'
     assert not extract_links(pagecontent, "https://test.com/", False)


### PR DESCRIPTION
extract_links/fix_relative_urls hits ValueError when malformed IPv6 protocol-relative href //[::1. This PR fixes the regression with a focused test covering the case. RED-GREEN proved; awaiting thermo