### PR TITLE
fix: do not treat empty href quotes as URLs

### DIFF
--- a/courlan/core.py
+++ b/courlan/core.py
@@ -33,7 +33,8 @@ LOGGER = logging.getLogger(__name__)
 
 FIND_LINKS_REGEX = re.compile(r"<a\s+[^<>]+?>", re.I)
 HREFLANG_REGEX = re.compile(r'hreflang=["\']?([a-z-]+)', re.I)
-LINK_REGEX = re.compile(r'href=["\']?([^ ]+?)(["\' >])', re.I)
+# *? so empty href="" / href='' do not capture the closing quote as the URL
+LINK_REGEX = re.compile(r'href=["\']?([^ ]*?)(["\' >])', re.I)
 
 
 def check_url(

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1248,6 +1248,21 @@ def test_extraction():
     # hreflang matches the target language but the tag has no href
     pagecontent = '<html><a hreflang="de-DE">no href</a></html>'
     assert not extract_links(pagecontent, "https://test.com/", False, language="de")
+    # empty quoted href must not capture the closing quote as a path (/%27)
+    pagecontent = "<html><a href=''>x</a></html>"
+    assert extract_links(pagecontent, "https://example.org", False) == {
+        "https://example.org"
+    }
+    assert extract_links(pagecontent, "https://example.org", no_filter=True) == {
+        "https://example.org"
+    }
+    pagecontent = '<html><a href="">x</a></html>'
+    assert extract_links(pagecontent, "https://example.org", False) == {
+        "https://example.org"
+    }
+    assert extract_links(pagecontent, "https://example.org", no_filter=True) == {
+        "https://example.org"
+    }
     # link known under another form
     pagecontent = '<html><a href="https://test.org/example"/><a href="https://test.org/example/&"/></html>'
     assert len(extract_links(pagecontent, "https://test.org", False)) == 1


### PR DESCRIPTION
`extract_links` turns an empty single-quoted href into a fake path. `LINK_REGEX` required at least one character inside the quotes, so for `href=''` it captured the closing quote and `check_url` normalized that to `/%27`.

Empty hrefs should resolve like other relative links (to the page URL). Allow an empty match in `LINK_REGEX`.

```python
from courlan import extract_links
extract_links("<html><a href=''>x</a></html>", "https://example.org")
# was {'https://example.org/%27'}
```