### PR TITLE
fix: accept bracketed IPv6 netlocs in domain_filter

### DIFF
--- a/courlan/filters.py
+++ b/courlan/filters.py
@@ -126,8 +126,22 @@ def domain_filter(domain: str) -> bool:
     # no valid FQDN exceeds the DNS length limit
     if len(domain) > 253:
         return False
-    # IP literal, or IPv4 with a port (a port-bearing host is still all-IP_SET,
-    # so reuse the gate; IPv6+port needs brackets, handled at the URL layer)
+    # Bracketed IPv6 netloc from urlsplit: [addr] or [addr]:port
+    if domain.startswith("["):
+        end = domain.find("]")
+        if end == -1:
+            return False
+        host, rest = domain[1:end], domain[end + 1 :]
+        if not _canonical_ip(host):
+            return False
+        if not rest:
+            return True
+        # port: 1-65535, no leading zero (same rule as IPv4+port below)
+        if rest[0] != ":":
+            return False
+        tail = rest[1:]
+        return bool(tail) and tail[:1] != "0" and tail.isdigit() and int(tail) < 65536
+    # IP literal, or IPv4 with a port (a port-bearing host is still all-IP_SET)
     if all(c in IP_SET for c in domain):
         if _canonical_ip(domain):
             return True

--- a/courlan/filters.py
+++ b/courlan/filters.py
@@ -121,6 +121,11 @@ def basic_filter(url: str) -> bool:
     return bool(url.startswith("http") and 10 <= len(url) < 500)
 
 
+def _valid_port(tail: str) -> bool:
+    "Port 1-65535 with no leading zero (mirrors VALID_DOMAIN_PORT's [1-9]... rule)."
+    return bool(tail) and tail[:1] != "0" and tail.isdigit() and int(tail) < 65536
+
+
 def domain_filter(domain: str) -> bool:
     "Find invalid domain/host names."
     # no valid FQDN exceeds the DNS length limit
@@ -134,26 +139,13 @@ def domain_filter(domain: str) -> bool:
         host, rest = domain[1:end], domain[end + 1 :]
         if not _canonical_ip(host):
             return False
-        if not rest:
-            return True
-        # port: 1-65535, no leading zero (same rule as IPv4+port below)
-        if rest[0] != ":":
-            return False
-        tail = rest[1:]
-        return bool(tail) and tail[:1] != "0" and tail.isdigit() and int(tail) < 65536
+        return not rest or (rest.startswith(":") and _valid_port(rest[1:]))
     # IP literal, or IPv4 with a port (a port-bearing host is still all-IP_SET)
     if all(c in IP_SET for c in domain):
         if _canonical_ip(domain):
             return True
         head, sep, tail = domain.rpartition(":")
-        # port: 1-65535, no leading zero (mirrors VALID_DOMAIN_PORT's [1-9]... rule)
-        if (
-            sep
-            and tail[:1] != "0"
-            and tail.isdigit()
-            and int(tail) < 65536
-            and _canonical_ip(head)
-        ):
+        if sep and _valid_port(tail) and _canonical_ip(head):
             return True
 
     # malformed domains: retry against the punycode form before rejecting

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -791,7 +791,15 @@ def test_urlcheck_domain():
     assert check_url("http://0127.0.0.1") is None
     # assert check_url("http://::1") is not None
     assert check_url("http://2001:0db8:85a3:0000:0000:8a2e:0370:7334") is not None
-    assert check_url("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]") is None
+    # bracketed form is what urlsplit produces for a valid IPv6 URL
+    assert check_url("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]") == (
+        "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+        "2001:db8:85a3::8a2e:370:7334",
+    )
+    assert check_url("http://[2001:db8::1]/page") == (
+        "http://[2001:db8::1]/page",
+        "2001:db8::1",
+    )
     assert check_url("http://1:2:3:4:5:6:7:8:9") is None
     # bare suffix has no registrable domain, though domain_filter alone accepts it
     assert check_url("https://a.ck/page") is None
@@ -806,6 +814,9 @@ def test_urlcheck_port():
     assert check_url("http://127.0.0.1:8080/x") is not None
     # out-of-range port on an IPv4 host is rejected like the domain form
     assert check_url("http://1.2.3.4:99999/x") is None
+    # bracketed IPv6 with a port (urlsplit netloc shape)
+    assert check_url("http://[::1]:8080/x") == ("http://[::1]:8080/x", "::1")
+    assert check_url("http://[::1]:99999/x") is None
 
 
 def test_domain_filter():
@@ -851,6 +862,15 @@ def test_domain_filter():
     assert domain_filter("1.2.3.4:99999") is False
     assert domain_filter("1.2.3.4:0") is False
     assert domain_filter("1.2.3.4:0080") is False  # leading zero rejected
+    # bracketed IPv6 (urlsplit netloc), with and without port
+    assert domain_filter("[::1]") is True
+    assert domain_filter("[2001:db8::1]") is True
+    assert domain_filter("[::1]:8080") is True
+    assert domain_filter("[::1]:0") is False
+    assert domain_filter("[::1]:0080") is False
+    assert domain_filter("[::1]:99999") is False
+    assert domain_filter("[not-an-ip]") is False
+    assert domain_filter("[::1") is False
 
     # hex-only strings that are not IPs must still be validated as domains
     assert domain_filter("abc.de") is True


### PR DESCRIPTION
`domain_filter` accepted bare IPv6 literals like `::1` but rejected the bracketed netloc `urlsplit` produces for a normal IPv6 URL. `check_url` therefore returned `None` for every properly formed IPv6 HTTP URL, while IPv4 peers passed.

Accept `[addr]` and `[addr]:port` with the same port rules as IPv4.

```python
from courlan import check_url
check_url("http://[2001:db8::1]/page")
# was None
```