### PR TITLE
Pass host without userinfo to domain_filter in check_url

### DIFF
--- a/courlan/core.py
+++ b/courlan/core.py
@@ -99,8 +99,9 @@ def check_url(
             LOGGER.debug("rejected, extension filter: %s", url)
             raise ValueError
 
-        # unsuitable domain/host name
-        if domain_filter(parsed_url.netloc) is False:
+        # unsuitable domain/host name (strip userinfo; domain_filter expects host[/port])
+        host = parsed_url.netloc.rsplit("@", 1)[-1]
+        if not host or domain_filter(host) is False:
             LOGGER.debug("rejected, domain name: %s", url)
             raise ValueError
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -556,6 +556,9 @@ def test_validate():
     assert not is_valid_url("http://1234")
     assert not is_valid_url("http://localhost/")
     assert not is_valid_url("http://a.b/")
+    # userinfo must not make check_url reject an otherwise-valid host
+    assert check_url("http://user@t.co/") is not None
+    assert check_url("https://user:pass@example.com/path") is not None
 
 
 def test_normalization():


### PR DESCRIPTION
`check_url` passed the full netloc (including userinfo) to `domain_filter`, so valid URLs like `http://user@t.co/` were rejected even though `is_valid_url` accepted them.

Strip userinfo before the domain check.